### PR TITLE
Improve performance

### DIFF
--- a/src/reducers/solves.js
+++ b/src/reducers/solves.js
@@ -15,9 +15,17 @@ export const getRecordedAtValues = state => {
   return state.entities.solves.recordedAtValues;
 };
 
+export const getAllSolvesByRecordedAt = state => {
+  return state.entities.solves.byRecordedAt.allSolves;
+};
+
+export const getMostRecentSolvesByRecordedAt = state => {
+  return state.entities.solves.byRecordedAt.mostRecentSolves;
+};
+
 export const getSolvesByRecordedAt = createSelector(
   getSolvesSelected,
-  state => state.entities.solves.byRecordedAt,
+  getAllSolvesByRecordedAt,
   (solvesSelected, solves) => {
     return Object
       .entries(solves)
@@ -33,10 +41,6 @@ export const getSolvesByRecordedAt = createSelector(
       );
   }
 );
-
-export const getMostRecentSolvesByRecordedAt = state => {
-  return state.entities.solves.mostRecentSolves;
-};
 
 export const getLastDeletedSolves = state => {
   return state.lastDeletedSolves;
@@ -150,36 +154,61 @@ function makeByRecordedAtReducer(initialState) {
       case DELETE_SOLVES:
         return Object
           .values(state)
-          .filter(
-            solve => !action.solves.some(({ recordedAt }) => solve.recordedAt === recordedAt)
-          )
-          .reduce(
-            (solves, solve) => ({
-              ...solves,
-              [solve.recordedAt]: solve
-            }),
-            {}
-          );
+          .filter(solve => !action.solves.some(({ recordedAt }) => solve.recordedAt === recordedAt))
+          .reduce((solves, solve) => ({ ...solves, [solve.recordedAt]: solve }), {});
       default:
         return state;
     }
   };
 }
 
-const initialByRecordedAtState = {};
+const initialAllSolvesState = {};
 
-const byRecordedAt = makeByRecordedAtReducer(initialByRecordedAtState);
+const allSolves = makeByRecordedAtReducer(initialAllSolvesState);
 
 const initialMostRecentSolvesState = {};
 
+const MOST_RECENT_LIMIT = 5;
+
+function limitSolves(byRecordedAt) {
+  return Object
+    .keys(byRecordedAt)
+    .sort()
+    .reverse()
+    .slice(0, MOST_RECENT_LIMIT)
+    .reduce((solvesByRecordedAt, recordedAt) => {
+      return {
+        ...solvesByRecordedAt,
+        [recordedAt]: byRecordedAt[recordedAt]
+      };
+    }, {});
+}
+
 function mostRecentSolves(state = initialMostRecentSolvesState, action) {
-  const updatedState = makeByRecordedAtReducer(initialMostRecentSolvesState)(state, action);
-  return Object.keys(updatedState).sort().reverse().slice(0, 5).reduce((solvesByRecordedAt, recordedAt) => {
-    return {
-      ...solvesByRecordedAt,
-      [recordedAt]: updatedState[recordedAt]
-    };
-  }, {});
+  const updatedMostRecentSolves = makeByRecordedAtReducer(initialMostRecentSolvesState)(state, action);
+  return limitSolves(updatedMostRecentSolves);
+}
+
+const initialByRecordedAtState = {
+  allSolves: initialAllSolvesState,
+  mostRecentSolves: initialMostRecentSolvesState
+};
+
+function byRecordedAt(state = initialByRecordedAtState, action) {
+  const updatedAllSolves = allSolves(state.allSolves, action);
+  let updatedMostRecentSolves = mostRecentSolves(state.mostRecentSolves, action);
+
+  const updatedMostRecentRecordedAtTimes = Object.keys(updatedMostRecentSolves);
+  const mostRecentCount = updatedMostRecentRecordedAtTimes.length;
+
+  if(mostRecentCount < MOST_RECENT_LIMIT && mostRecentCount < Object.keys(updatedAllSolves).length) {
+    updatedMostRecentSolves = limitSolves(updatedAllSolves);
+  }
+
+  return {
+    allSolves: updatedAllSolves,
+    mostRecentSolves: updatedMostRecentSolves
+  };
 }
 
 const initialLastDeletedState = [];
@@ -220,6 +249,5 @@ export function recordedAtValues(state = initialRecordedAtValuesState, action) {
 
 export default combineReducers({
   byRecordedAt,
-  recordedAtValues,
-  mostRecentSolves
+  recordedAtValues
 });


### PR DESCRIPTION
## Seems like this didn't help at all so it might just be the sheet number of solves making state updates too computationally expensive. Will have to do some additional investigation to find the source of the problem or just stop storing all the solves in memory.

For large solve sets (1000s of solves) there is noticeable jank (on the order of seconds) when stopping the timer or deleting the last solve. Hypothesis is that this is because the whole solve list is being traversed whenever the last solve changes, because memoization misses on the data structures containing the solves when even one solve is added or removed. 

Current solution is to store the most recent N solves (in this case 5 so we can calculate up to averages of 5) in a separate data structure that gets updated in tandem with the data structures containing all the solves. This works as-is for everything but deletion, since we're not putting old solves back into the most recent list when a solve gets deleted. I think a naive approach would suffer from the same performance pitfalls as the old solution, since we'd have to traverse the entire list of old solves to determine what solves to put back into the most recent list, and memoization would miss on the old list because we'd have removed the deleted solve from there as well.

Initial ideas for a true solution would be to create some sort of bipartitioned list that has a "hot zone", where most of the operations are taking place, and a "cold zone" where the old solves would be stored (no duplicated items between the list). Hot zone addition would push the oldest item to the cold zone, hot zone deletion would pull the youngest item from the cold zone. This way we'd get memoization hits on the cold zone when deleting items from the hot zone and need to back-populate the hot zone.

Should proof-of-concept this in the code by hacking something together, but ultimately would be handy as an opaque immutable data structure that would handle passing items between hot and cold zones automatically.

**UPDATE**: Went with a naive delete solution for now. Deletion should still be slow with large solve sets but stopping the timer should be fast now.